### PR TITLE
format code + get robot_ids_ from yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format

--- a/nlu_interface_rviz/include/nlu_interface_rviz/instruction_panel.hpp
+++ b/nlu_interface_rviz/include/nlu_interface_rviz/instruction_panel.hpp
@@ -2,73 +2,80 @@
 #define NLU_INTERFACE_RVIZ__INSTRUCTION_PANEL_HPP_
 
 // ROS
+#include "rclcpp/rclcpp.hpp"
+#include <omniplanner_msgs/msg/goto_points_goal_msg.hpp>
+#include <omniplanner_msgs/msg/language_goal_msg.hpp>
+#include <ros_system_monitor_msgs/msg/node_info_msg.hpp>
 #include <rviz_common/panel.hpp>
 #include <rviz_common/ros_integration/ros_node_abstraction_iface.hpp>
-#include <std_msgs/msg/string.hpp>
 #include <std_msgs/msg/bool.hpp>
-#include <ros_system_monitor_msgs/msg/node_info_msg.hpp>
-#include <omniplanner_msgs/msg/language_goal_msg.hpp>
-#include <omniplanner_msgs/msg/goto_points_goal_msg.hpp>
+#include <std_msgs/msg/string.hpp>
 //#include <nlu_interface_rviz/msg/manipulation_approval_request.hpp>
 
 // Qt
-#include <QLabel>
-#include <QTextEdit>
-#include <QLineEdit>
 #include <QComboBox>
-#include <QRadioButton>
+#include <QLabel>
+#include <QLineEdit>
 #include <QPushButton>
-#include <QTimer>
+#include <QRadioButton>
 #include <QSet>
 #include <QString>
+#include <QTextEdit>
+#include <QTimer>
 
 namespace nlu_interface_rviz {
-class InstructionPanel : public rviz_common::Panel
-{
-    Q_OBJECT
+class InstructionPanel : public rviz_common::Panel {
+  Q_OBJECT
 public:
-    explicit InstructionPanel(QWidget * parent = 0);
-    ~InstructionPanel() override = default;
-    void onInitialize() override;
+  explicit InstructionPanel(QWidget *parent = 0);
+  ~InstructionPanel() override = default;
+  void onInitialize() override;
 
 protected:
+  void publishManipulationResponse(bool const approve);
 
-    void publishManipulationResponse( bool const approve );
+  // ROS callbacks
+  void handleLLMResponse(std_msgs::msg::String const &msg);
+  void handleManipulationRequest(
+      std_msgs::msg::String const
+          &msg); // TODO: Use ManipulationApprovalRequest message
+  // Data members
+  QSet<QString> robot_ids_;
 
-    // ROS callbacks
-    void handleLLMResponse( std_msgs::msg::String const & msg );
-    void handleManipulationRequest( std_msgs::msg::String const & msg ); // TODO: Use ManipulationApprovalRequest message
-    // Data members
-    QSet<QString> robot_ids_;
+  // ROS2 member variables
+  std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface>
+      p_node_abstraction_;
+  rclcpp::Publisher<omniplanner_msgs::msg::LanguageGoalMsg>::SharedPtr
+      instruction_publisher_;
+  rclcpp::Publisher<ros_system_monitor_msgs::msg::NodeInfoMsg>::SharedPtr
+      system_monitor_publisher_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr
+      llm_response_subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr
+      manipulation_request_subscription_;
+  // map of robot ids to ros publishers
+  std::map<std::string, rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr>
+      manipulation_approval_publishers_;
 
-
-    // ROS2 member variables
-    std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> p_node_abstraction_;
-    rclcpp::Publisher<omniplanner_msgs::msg::LanguageGoalMsg>::SharedPtr instruction_publisher_;
-    rclcpp::Publisher<ros_system_monitor_msgs::msg::NodeInfoMsg>::SharedPtr system_monitor_publisher_;
-    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr llm_response_subscription_;
-    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr manipulation_request_subscription_;
-    // map of robot ids to ros publishers
-    std::map< std::string, rclcpp::Publisher< std_msgs::msg::Bool >::SharedPtr> manipulation_approval_publishers_;
-
-    // GUI member variables
-    QTextEdit * p_llm_response_textbox_;
-    QLineEdit * p_prev_instruction_editor_;
-    QLineEdit * p_instruction_editor_;
-    QComboBox * p_domain_type_combo_box_;
-    QComboBox * p_robot_id_combo_box_;
-    QComboBox * p_manipulation_robot_id_combo_box_;
-    QLabel * p_manipulation_image_label_; //TODO: Display a sensor_msgs/Image as a QLabel
-    QPushButton * p_manipulation_approve_push_button_;
-    QPushButton * p_manipulation_reject_push_button_;
-    QTimer * p_timer_;
+  // GUI member variables
+  QTextEdit *p_llm_response_textbox_;
+  QLineEdit *p_prev_instruction_editor_;
+  QLineEdit *p_instruction_editor_;
+  QComboBox *p_domain_type_combo_box_;
+  QComboBox *p_robot_id_combo_box_;
+  QComboBox *p_manipulation_robot_id_combo_box_;
+  QLabel *p_manipulation_image_label_; // TODO: Display a sensor_msgs/Image as a
+                                       // QLabel
+  QPushButton *p_manipulation_approve_push_button_;
+  QPushButton *p_manipulation_reject_push_button_;
+  QTimer *p_timer_;
 
 private Q_SLOTS:
-    void publishInstruction( void );
-    void publishManipulationApproval( void );
-    void publishManipulationRejection( void );
-    void publishSystemMonitor( void );
+  void publishInstruction(void);
+  void publishManipulationApproval(void);
+  void publishManipulationRejection(void);
+  void publishSystemMonitor(void);
 }; // class InstructionPanel
-}  // namespace nlu_interface_rviz
+} // namespace nlu_interface_rviz
 
-#endif  // NLU_INTERFACE_RVIZ__INSTRUCTION_PANEL_HPP_
+#endif // NLU_INTERFACE_RVIZ__INSTRUCTION_PANEL_HPP_

--- a/nlu_interface_rviz/src/instruction_panel.cpp
+++ b/nlu_interface_rviz/src/instruction_panel.cpp
@@ -1,170 +1,197 @@
-#include <nlu_interface_rviz/instruction_panel.hpp>
 #include <QVBoxLayout>
+#include <nlu_interface_rviz/instruction_panel.hpp>
 #include <rviz_common/display_context.hpp>
 
 namespace nlu_interface_rviz {
-InstructionPanel::InstructionPanel(QWidget* parent) : Panel(parent) {
-    // Initialize the robot ids
-    robot_ids_ = {"euclid", "hamilton", "hilbert"};
+InstructionPanel::InstructionPanel(QWidget *parent) : Panel(parent) {
+  // Initialize the robot ids
+  p_node_abstraction_ = getDisplayContext()->getRosNodeAbstraction().lock();
+  rclcpp::Node::SharedPtr node = p_node_abstraction_->get_raw_node();
+  node->declare_parameter<std::vector<std::string>>("robot_ids", {"euclid"});
+  auto strs = node->get_parameter("robot_ids").as_string_array();
+  for (auto &s : strs) {
+    robot_ids_.insert(s.c_str());
+  }
 
-    // Create the layout for the domain type combo box
-    QHBoxLayout * p_domain_type_combo_box_layout = new QHBoxLayout;
-    p_domain_type_combo_box_layout->addWidget( new QLabel("Domain Type"));
-    p_domain_type_combo_box_ = new QComboBox;
-    p_domain_type_combo_box_->addItems({"default", "Pddl", "goto_points"});
-    p_domain_type_combo_box_layout->addWidget( p_domain_type_combo_box_ );
+  // Create the layout for the domain type combo box
+  QHBoxLayout *p_domain_type_combo_box_layout = new QHBoxLayout;
+  p_domain_type_combo_box_layout->addWidget(new QLabel("Domain Type"));
+  p_domain_type_combo_box_ = new QComboBox;
+  p_domain_type_combo_box_->addItems({"default", "Pddl", "goto_points"});
+  p_domain_type_combo_box_layout->addWidget(p_domain_type_combo_box_);
 
-    // Create the layout for the robot id combo box
-    QHBoxLayout * p_robot_id_combo_box_layout = new QHBoxLayout;
-    p_robot_id_combo_box_layout->addWidget( new QLabel("Robot ID"));
-    p_robot_id_combo_box_ = new QComboBox;
-    p_robot_id_combo_box_->addItems(QList<QString>(robot_ids_.begin(), robot_ids_.end()));
-    p_robot_id_combo_box_layout->addWidget( p_robot_id_combo_box_ );
+  // Create the layout for the robot id combo box
+  QHBoxLayout *p_robot_id_combo_box_layout = new QHBoxLayout;
+  p_robot_id_combo_box_layout->addWidget(new QLabel("Robot ID"));
+  p_robot_id_combo_box_ = new QComboBox;
+  p_robot_id_combo_box_->addItems(
+      QList<QString>(robot_ids_.begin(), robot_ids_.end()));
+  p_robot_id_combo_box_layout->addWidget(p_robot_id_combo_box_);
 
-    // Create the layout for the instruction field
-    QHBoxLayout * p_instruction_layout = new QHBoxLayout;
-    p_instruction_layout->addWidget( new QLabel("Instruction:"));
-    p_instruction_editor_ = new QLineEdit;
-    p_instruction_layout->addWidget( p_instruction_editor_ );
+  // Create the layout for the instruction field
+  QHBoxLayout *p_instruction_layout = new QHBoxLayout;
+  p_instruction_layout->addWidget(new QLabel("Instruction:"));
+  p_instruction_editor_ = new QLineEdit;
+  p_instruction_layout->addWidget(p_instruction_editor_);
 
-    // Create the layout for a display of the previously published instruction
-    QHBoxLayout * p_prev_instruction_layout = new QHBoxLayout;
-    p_prev_instruction_layout->addWidget( new QLabel("Published Instruction:"));
-    p_prev_instruction_editor_ = new QLineEdit;
-    p_prev_instruction_editor_->setReadOnly(true);
-    p_prev_instruction_layout->addWidget( p_prev_instruction_editor_ );
+  // Create the layout for a display of the previously published instruction
+  QHBoxLayout *p_prev_instruction_layout = new QHBoxLayout;
+  p_prev_instruction_layout->addWidget(new QLabel("Published Instruction:"));
+  p_prev_instruction_editor_ = new QLineEdit;
+  p_prev_instruction_editor_->setReadOnly(true);
+  p_prev_instruction_layout->addWidget(p_prev_instruction_editor_);
 
-    // Create the layout for a display of the response from the LLM
-    QHBoxLayout * p_llm_response_layout = new QHBoxLayout;
-    p_llm_response_layout->addWidget( new QLabel("LLM Response"));
-    p_llm_response_textbox_ = new QTextEdit;
-    p_llm_response_textbox_->setReadOnly(true);
-    p_llm_response_layout->addWidget( p_llm_response_textbox_ );
+  // Create the layout for a display of the response from the LLM
+  QHBoxLayout *p_llm_response_layout = new QHBoxLayout;
+  p_llm_response_layout->addWidget(new QLabel("LLM Response"));
+  p_llm_response_textbox_ = new QTextEdit;
+  p_llm_response_textbox_->setReadOnly(true);
+  p_llm_response_layout->addWidget(p_llm_response_textbox_);
 
-    // Create the layout for a display of a manipulation request image
-    QVBoxLayout * p_manipulation_request_layout = new QVBoxLayout;
-    p_manipulation_request_layout->addWidget( new QLabel("Manipulation Approval Request"));
-    p_manipulation_image_label_ = new QLabel("Manipulation Image Placeholder");
-    p_manipulation_request_layout->addWidget( p_manipulation_image_label_ );
+  // Create the layout for a display of a manipulation request image
+  QVBoxLayout *p_manipulation_request_layout = new QVBoxLayout;
+  p_manipulation_request_layout->addWidget(
+      new QLabel("Manipulation Approval Request"));
+  p_manipulation_image_label_ = new QLabel("Manipulation Image Placeholder");
+  p_manipulation_request_layout->addWidget(p_manipulation_image_label_);
 
-    // Create the layout for the approval robot id
-    QHBoxLayout * p_manipulation_robot_id_combo_box_layout = new QHBoxLayout;
-    p_manipulation_robot_id_combo_box_layout->addWidget( new QLabel("Robot ID"));
-    p_manipulation_robot_id_combo_box_ = new QComboBox;
-    p_manipulation_robot_id_combo_box_->addItems(QList<QString>(robot_ids_.begin(), robot_ids_.end()));
-    p_manipulation_robot_id_combo_box_layout->addWidget( p_manipulation_robot_id_combo_box_ );
+  // Create the layout for the approval robot id
+  QHBoxLayout *p_manipulation_robot_id_combo_box_layout = new QHBoxLayout;
+  p_manipulation_robot_id_combo_box_layout->addWidget(new QLabel("Robot ID"));
+  p_manipulation_robot_id_combo_box_ = new QComboBox;
+  p_manipulation_robot_id_combo_box_->addItems(
+      QList<QString>(robot_ids_.begin(), robot_ids_.end()));
+  p_manipulation_robot_id_combo_box_layout->addWidget(
+      p_manipulation_robot_id_combo_box_);
 
-    QHBoxLayout * p_manipulation_approval_layout = new QHBoxLayout;
-    p_manipulation_approve_push_button_ = new QPushButton("Approve");
-    p_manipulation_approval_layout->addWidget( p_manipulation_approve_push_button_ );
-    p_manipulation_reject_push_button_ = new QPushButton("Reject");
-    p_manipulation_approval_layout->addWidget( p_manipulation_reject_push_button_ );
+  QHBoxLayout *p_manipulation_approval_layout = new QHBoxLayout;
+  p_manipulation_approve_push_button_ = new QPushButton("Approve");
+  p_manipulation_approval_layout->addWidget(
+      p_manipulation_approve_push_button_);
+  p_manipulation_reject_push_button_ = new QPushButton("Reject");
+  p_manipulation_approval_layout->addWidget(p_manipulation_reject_push_button_);
 
-    // Organize the layouts vertically
-    QVBoxLayout * p_layout = new QVBoxLayout;
-    p_layout->addLayout( p_domain_type_combo_box_layout );
-    p_layout->addLayout( p_robot_id_combo_box_layout );
-    p_layout->addLayout( p_instruction_layout );
-    p_layout->addLayout( p_prev_instruction_layout );
-    p_layout->addLayout( p_llm_response_layout );
-    p_layout->addLayout( p_manipulation_request_layout );
-    p_layout->addLayout( p_manipulation_robot_id_combo_box_layout );
-    p_layout->addLayout( p_manipulation_approval_layout );
-    setLayout( p_layout );
+  // Organize the layouts vertically
+  QVBoxLayout *p_layout = new QVBoxLayout;
+  p_layout->addLayout(p_domain_type_combo_box_layout);
+  p_layout->addLayout(p_robot_id_combo_box_layout);
+  p_layout->addLayout(p_instruction_layout);
+  p_layout->addLayout(p_prev_instruction_layout);
+  p_layout->addLayout(p_llm_response_layout);
+  p_layout->addLayout(p_manipulation_request_layout);
+  p_layout->addLayout(p_manipulation_robot_id_combo_box_layout);
+  p_layout->addLayout(p_manipulation_approval_layout);
+  setLayout(p_layout);
 
-    // Create a timer to regularly publish to the system monitor
-    QTimer * p_timer_ = new QTimer(this);
+  // Create a timer to regularly publish to the system monitor
+  QTimer *p_timer_ = new QTimer(this);
 
-    // Create Qt connections
-    QObject::connect( p_instruction_editor_, SIGNAL(returnPressed()), this, SLOT(publishInstruction()) );
-    QObject::connect( p_manipulation_approve_push_button_, SIGNAL(clicked()), this, SLOT(publishManipulationApproval()) );
-    QObject::connect( p_manipulation_reject_push_button_, SIGNAL(clicked()), this, SLOT(publishManipulationRejection()) );
-    QObject::connect( p_timer_, &QTimer::timeout, this, &InstructionPanel::publishSystemMonitor );
-    p_timer_->start(500);
-    return;
+  // Create Qt connections
+  QObject::connect(p_instruction_editor_, SIGNAL(returnPressed()), this,
+                   SLOT(publishInstruction()));
+  QObject::connect(p_manipulation_approve_push_button_, SIGNAL(clicked()), this,
+                   SLOT(publishManipulationApproval()));
+  QObject::connect(p_manipulation_reject_push_button_, SIGNAL(clicked()), this,
+                   SLOT(publishManipulationRejection()));
+  QObject::connect(p_timer_, &QTimer::timeout, this,
+                   &InstructionPanel::publishSystemMonitor);
+  p_timer_->start(500);
+  return;
 }
 
-void InstructionPanel::onInitialize(){
-    p_node_abstraction_ = getDisplayContext()->getRosNodeAbstraction().lock();
-    rclcpp::Node::SharedPtr node = p_node_abstraction_->get_raw_node();
+void InstructionPanel::onInitialize() {
+  p_node_abstraction_ = getDisplayContext()->getRosNodeAbstraction().lock();
+  rclcpp::Node::SharedPtr node = p_node_abstraction_->get_raw_node();
 
-    // Create the publishers
-    instruction_publisher_ = node->create_publisher<omniplanner_msgs::msg::LanguageGoalMsg>("omniplanner_node/language_planner/language_goal", 10);
-    system_monitor_publisher_ = node->create_publisher<ros_system_monitor_msgs::msg::NodeInfoMsg>("~/node_status", 1);
-    // Create a manipulation approval publisher namespaced for each robot
-    for( auto const & q_robot_id : robot_ids_ ){
-        auto const robot_id = q_robot_id.toStdString();
-        auto const topic = robot_id + "/manipulation_approval";
-        manipulation_approval_publishers_.emplace(
-            robot_id, node->create_publisher<std_msgs::msg::Bool>(topic, 1)
-        );
-    }
-    // Create the subscriptions
-    llm_response_subscription_ = node->create_subscription<std_msgs::msg::String>("~/llm_response", 10, std::bind(&InstructionPanel::handleLLMResponse, this, std::placeholders::_1));
-    manipulation_request_subscription_ = node->create_subscription<std_msgs::msg::String>("~/manipulation_request", 10, std::bind(&InstructionPanel::handleManipulationRequest, this, std::placeholders::_1));
-    return;
+  // Create the publishers
+  instruction_publisher_ =
+      node->create_publisher<omniplanner_msgs::msg::LanguageGoalMsg>(
+          "omniplanner_node/language_planner/language_goal", 10);
+  system_monitor_publisher_ =
+      node->create_publisher<ros_system_monitor_msgs::msg::NodeInfoMsg>(
+          "~/node_status", 1);
+  // Create a manipulation approval publisher namespaced for each robot
+  for (auto const &q_robot_id : robot_ids_) {
+    auto const robot_id = q_robot_id.toStdString();
+    auto const topic = robot_id + "/manipulation_approval";
+    manipulation_approval_publishers_.emplace(
+        robot_id, node->create_publisher<std_msgs::msg::Bool>(topic, 1));
+  }
+  // Create the subscriptions
+  llm_response_subscription_ = node->create_subscription<std_msgs::msg::String>(
+      "~/llm_response", 10,
+      std::bind(&InstructionPanel::handleLLMResponse, this,
+                std::placeholders::_1));
+  manipulation_request_subscription_ =
+      node->create_subscription<std_msgs::msg::String>(
+          "~/manipulation_request", 10,
+          std::bind(&InstructionPanel::handleManipulationRequest, this,
+                    std::placeholders::_1));
+  return;
 }
 
-void InstructionPanel::handleLLMResponse(std_msgs::msg::String const & msg ){
-    p_llm_response_textbox_->setText( msg.data.c_str() ); 
-    return;
+void InstructionPanel::handleLLMResponse(std_msgs::msg::String const &msg) {
+  p_llm_response_textbox_->setText(msg.data.c_str());
+  return;
 }
 
-void InstructionPanel::handleManipulationRequest(std_msgs::msg::String const & msg ){
-    p_manipulation_image_label_->setText( msg.data.c_str() );
-    return;
+void InstructionPanel::handleManipulationRequest(
+    std_msgs::msg::String const &msg) {
+  p_manipulation_image_label_->setText(msg.data.c_str());
+  return;
 }
 
-void InstructionPanel::publishInstruction( void ){
-    // Construct and publish the instruction text as a String message 
-    auto msg = omniplanner_msgs::msg::LanguageGoalMsg();
-    msg.robot_id = p_robot_id_combo_box_->currentText().toStdString();
-    msg.command = p_instruction_editor_->text().toStdString();
-    msg.domain_type = p_domain_type_combo_box_->currentText().toStdString();
-    instruction_publisher_->publish( msg );
+void InstructionPanel::publishInstruction(void) {
+  // Construct and publish the instruction text as a String message
+  auto msg = omniplanner_msgs::msg::LanguageGoalMsg();
+  msg.robot_id = p_robot_id_combo_box_->currentText().toStdString();
+  msg.command = p_instruction_editor_->text().toStdString();
+  msg.domain_type = p_domain_type_combo_box_->currentText().toStdString();
+  instruction_publisher_->publish(msg);
 
-    // Update the display for the previous instruction
-    p_prev_instruction_editor_->setText( p_instruction_editor_->text() );
-    return;
+  // Update the display for the previous instruction
+  p_prev_instruction_editor_->setText(p_instruction_editor_->text());
+  return;
 }
 
-void InstructionPanel::publishManipulationApproval( void ){
-    publishManipulationResponse(true);
-    return;
+void InstructionPanel::publishManipulationApproval(void) {
+  publishManipulationResponse(true);
+  return;
 }
 
-void InstructionPanel::publishManipulationRejection( void ){
-    publishManipulationResponse(false);
-    return;
+void InstructionPanel::publishManipulationRejection(void) {
+  publishManipulationResponse(false);
+  return;
 }
 
-void InstructionPanel::publishManipulationResponse( bool const approve ){
-    // Construct the approval message (bool)
-    auto msg = std_msgs::msg::Bool();
-    msg.data = approve;
-    // Get the publisher for the selected robot id
-    auto it_publisher = manipulation_approval_publishers_.find( p_manipulation_robot_id_combo_box_->currentText().toStdString() );
-    assert( it_publisher != manipulation_approval_publishers_.end() );
-    // Publish the approval message
-    it_publisher->second->publish( msg );
-    return;
+void InstructionPanel::publishManipulationResponse(bool const approve) {
+  // Construct the approval message (bool)
+  auto msg = std_msgs::msg::Bool();
+  msg.data = approve;
+  // Get the publisher for the selected robot id
+  auto it_publisher = manipulation_approval_publishers_.find(
+      p_manipulation_robot_id_combo_box_->currentText().toStdString());
+  assert(it_publisher != manipulation_approval_publishers_.end());
+  // Publish the approval message
+  it_publisher->second->publish(msg);
+  return;
 }
 
-void InstructionPanel::publishSystemMonitor( void ){
-    // Get the ROS2 node
-    auto p_node = p_node_abstraction_->get_raw_node();
+void InstructionPanel::publishSystemMonitor(void) {
+  // Get the ROS2 node
+  auto p_node = p_node_abstraction_->get_raw_node();
 
-    // Construct the message
-    auto msg = ros_system_monitor_msgs::msg::NodeInfoMsg();
-    msg.nickname = "nlu_rviz_panel";
-    msg.node_name = p_node->get_fully_qualified_name();
-    msg.status = ros_system_monitor_msgs::msg::NodeInfoMsg::NOMINAL;
-    msg.notes = "You gonna give me orders?";
-    system_monitor_publisher_->publish( msg );
-    return;
+  // Construct the message
+  auto msg = ros_system_monitor_msgs::msg::NodeInfoMsg();
+  msg.nickname = "nlu_rviz_panel";
+  msg.node_name = p_node->get_fully_qualified_name();
+  msg.status = ros_system_monitor_msgs::msg::NodeInfoMsg::NOMINAL;
+  msg.notes = "You gonna give me orders?";
+  system_monitor_publisher_->publish(msg);
+  return;
 }
 
-}  // namespace nlu_interface_rviz
+} // namespace nlu_interface_rviz
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(nlu_interface_rviz::InstructionPanel, rviz_common::Panel)


### PR DESCRIPTION
@arkinj My original intent was just to try setting the list of robot ids from yaml, and I think I succeeded at that although have yet to test (but it compiles, which is what I was most worried about). But then my vim formatted the code, and I realized the repo had no existing formatter installed. Do you have a preference for how to deal with code formatting? I added clang-format as a .pre-commit step and ran it. It makes this diff ugly so happy to try and do that separately or use something else to format the code, but I think it's worth having some autoformatter. I am going to test this functionality for setting the robot ids tomorrow but let me know how you want to proceed with dealing with the formatting. 